### PR TITLE
Updated to match v1.4

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
-appVersion: "1.0"
+# Version of Calico.
+# Note: Actual images used are updated in values.yaml
+appVersion: "3.3.6"
 description: A Helm chart for installing Calico
 name: Calico
-version: 0.1.0
+# Matches config version released by AWS under
+# https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config/
+version: 1.4

--- a/templates/CustomResourceDefinition.yaml
+++ b/templates/CustomResourceDefinition.yaml
@@ -59,7 +59,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   names:
     kind: HostEndpoint
     plural: hostendpoints
@@ -75,7 +78,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: ClusterInformation
     plural: clusterinformations
@@ -91,7 +97,11 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
@@ -107,7 +117,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
@@ -123,8 +136,26 @@ metadata:
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   names:
     kind: NetworkPolicy
     plural: networkpolicies
     singular: networkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer

--- a/templates/CustomResourceDefinition.yaml
+++ b/templates/CustomResourceDefinition.yaml
@@ -4,7 +4,6 @@
 # Calico policy-only mode.
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
    name: felixconfigurations.crd.projectcalico.org
@@ -20,7 +19,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -36,7 +34,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -52,7 +49,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Host Endpoints
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -71,7 +67,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Cluster Information
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -90,7 +85,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -110,7 +104,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Sets
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -129,7 +122,6 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org

--- a/templates/DaemonSet.yaml
+++ b/templates/DaemonSet.yaml
@@ -25,6 +25,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: {{ .Values.spec.hostNetwork }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       serviceAccountName: {{ .Values.spec.serviceAccountName }}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
@@ -34,7 +36,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ .Values.image }}
+          image: {{ .Values.image.node }}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -59,6 +61,8 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: {{ .Values.env.FELIX_DEFAULTENDPOINTTOHOSTACTION | quote }}
+            - name: FELIX_IPTABLESMANGLEALLOWACTION
+              value: {{ .Values.env.FELIX_IPTABLESMANGLEALLOWACTION | quote }}
             # Disable IPV6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: {{ .Values.env.FELIX_IPV6SUPPORT | quote }}
@@ -92,16 +96,23 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: {{ .Values.failureThreshold }}
           readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
               readOnly: false
       volumes:
         # Used to ensure proper kmods are installed.
@@ -111,6 +122,17 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        - hostPath:
+            path: /var/lib/calico
+          name: var-lib-calico
+        - hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+          name: xtables-lock
       tolerations:
-        # Make sure calico/node gets scheduled on all nodes.
-      - operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists

--- a/templates/Deployment.yaml
+++ b/templates/Deployment.yaml
@@ -13,14 +13,18 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
-      - operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
       hostNetwork: true
       serviceAccountName: calico-node
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
-      - image: quay.io/calico/typha:v0.7.4
+      - image: {{ .Values.image.typha }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -48,26 +52,23 @@ spec:
             value: "1"
           - name: TYPHA_HEALTHENABLED
             value: "true"
-        volumeMounts:
-        - mountPath: /etc/calico
-          name: etc-calico
-          readOnly: true
+          - name: FELIX_IPTABLESMANGLEALLOWACTION
+            value: {{ .Values.env.FELIX_IPTABLESMANGLEALLOWACTION | quote }}
         livenessProbe:
-          httpGet:
-            path: /liveness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - liveness
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - readiness
           periodSeconds: 10
-      volumes:
-      - name: etc-calico
-        hostPath:
-          path: /etc/calico
-
 ---
 
 apiVersion: extensions/v1beta1
@@ -86,6 +87,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler

--- a/templates/policy.yaml
+++ b/templates/policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    k8s-app: calico-typha
+  name: calico-typha
+  namespace: kube-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-typha

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -8,6 +8,7 @@ rules:
   - apiGroups: [""]
     resources:
       - namespaces
+      - serviceaccounts
     verbs:
       - get
       - list
@@ -16,7 +17,7 @@ rules:
     resources:
       - pods/status
     verbs:
-      - update
+      - patch
   - apiGroups: [""]
     resources:
       - pods
@@ -24,7 +25,6 @@ rules:
       - get
       - list
       - watch
-      - patch
   - apiGroups: [""]
     resources:
       - services

--- a/values.yaml
+++ b/values.yaml
@@ -5,11 +5,13 @@
 # Daemonset Settings
 name: calico-node
 namespace: kube-system
-image: quay.io/calico/node:v3.1.3
+image:
+  node: quay.io/calico/node:v3.3.6
+  typha: quay.io/calico/typha:v3.3.6
 updateStrategy:
   type: RollingUpdate
 
-failureThreshold: 8
+failureThreshold: 6
 
 spec:
   hostNetwork: true
@@ -31,6 +33,7 @@ env:
   FELIX_TYPHAK8SSERVICENAME: calico-typha
   # Set Felix endpoint to host default action to ACCEPT.
   FELIX_DEFAULTENDPOINTTOHOSTACTION: ACCEPT
+  FELIX_IPTABLESMANGLEALLOWACTION: Return
   # Disable IPV6 on Kubernetes.
   FELIX_IPV6SUPPORT: false
   # Wait for the datastore.


### PR DESCRIPTION
Took what's in https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.4/calico.yaml commit 7972d9a3674a4d971080426ffeff16a70ead18d0 to the amazon-vpc-cni-k8s project and modified the helm chart so the output is exactly the same.

Used a small [python snippet](https://gist.github.com/forsberg/6011f156d2f2d1a1577271640ba1ccac) to compare the two versions. The only difference is now that the helm chart has correct spelling on one of the annotations :-)