### PR TITLE
Updated to match v1.5.3 from Amazon

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # Version of Calico.
 # Note: Actual images used are updated in values.yaml
-appVersion: "3.3.6"
+appVersion: "3.8.1"
 description: A Helm chart for installing Calico
 name: Calico
 # Matches config version released by AWS under
 # https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config/
-version: 1.4
+version: 1.5.3

--- a/templates/CustomResourceDefinition.yaml
+++ b/templates/CustomResourceDefinition.yaml
@@ -6,11 +6,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -21,16 +24,71 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
     singular: bgpconfiguration
 
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -40,7 +98,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IPPool
     plural: ippools
@@ -56,9 +117,9 @@ spec:
   scope: Cluster
   group: crd.projectcalico.org
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: HostEndpoint
     plural: hostendpoints
@@ -92,10 +153,9 @@ spec:
   scope: Cluster
   group: crd.projectcalico.org
   versions:
-  - name: v1
-    served: true
-    storage: true
-
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
@@ -111,9 +171,9 @@ spec:
   scope: Cluster
   group: crd.projectcalico.org
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
@@ -129,9 +189,9 @@ spec:
   scope: Namespaced
   group: crd.projectcalico.org
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: NetworkPolicy
     plural: networkpolicies
@@ -142,12 +202,17 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: bgppeers.crd.projectcalico.org
+  name: networksets.crd.projectcalico.org
 spec:
-  scope: Cluster
+  scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
-    kind: BGPPeer
-    plural: bgppeers
-    singular: bgppeer
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset
+
+---

--- a/templates/DaemonSet.yaml
+++ b/templates/DaemonSet.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}

--- a/templates/Deployment.yaml
+++ b/templates/Deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -8,6 +8,9 @@ metadata:
     k8s-app: calico-typha
 spec:
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      k8s-app: calico-typha
   template:
     metadata:
       labels:
@@ -55,23 +58,22 @@ spec:
           - name: FELIX_IPTABLESMANGLEALLOWACTION
             value: {{ .Values.env.FELIX_IPTABLESMANGLEALLOWACTION | quote }}
         livenessProbe:
-          exec:
-            command:
-            - calico-typha
-            - check
-            - liveness
+          httpGet:
+            path: /liveness
+            port: 9098
+            host: localhost
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
-          exec:
-            command:
-            - calico-typha
-            - check
-            - readiness
+          httpGet:
+            path: /readiness
+            port: 9098
+            host: localhost
           periodSeconds: 10
+
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha-horizontal-autoscaler
@@ -79,6 +81,9 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
 spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-typha-autoscaler
   replicas: 1
   template:
     metadata:

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,7 +1,7 @@
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
@@ -18,6 +18,12 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
   - apiGroups: [""]
     resources:
       - pods
@@ -64,9 +70,11 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
       - networkpolicies
+      - networksets
       - clusterinformations
       - hostendpoints
     verbs:
@@ -75,10 +83,26 @@ rules:
       - list
       - update
       - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -87,13 +111,13 @@ roleRef:
   kind: ClusterRole
   name: calico-node
 subjects:
-- kind: ServiceAccount
-  name: calico-node
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: calico-node
+    namespace: kube-system
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: typha-cpha
@@ -108,7 +132,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: typha-cpha
@@ -119,7 +143,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: typha-cpha
@@ -134,7 +158,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: typha-cpha

--- a/values.yaml
+++ b/values.yaml
@@ -6,8 +6,8 @@
 name: calico-node
 namespace: kube-system
 image:
-  node: quay.io/calico/node:v3.3.6
-  typha: quay.io/calico/typha:v3.3.6
+  node: quay.io/calico/node:v3.8.1
+  typha: quay.io/calico/typha:v3.8.1
 updateStrategy:
   type: RollingUpdate
 


### PR DESCRIPTION
New release from Amazon.

Source: https://github.com/aws/amazon-vpc-cni-k8s/commit/a3045f86438d3432b8b5bf1e22899a63d245c627

Compared output from helm template with https://gist.github.com/forsberg/6011f156d2f2d1a1577271640ba1ccac, matches perfectly.